### PR TITLE
STEP 5: ADD MISSILE CONTROL

### DIFF
--- a/arcadesimplex.html
+++ b/arcadesimplex.html
@@ -33,6 +33,7 @@ function init()
     boom.material.diffuseColor=new BABYLON.Color3(1,.5,0);
     boom.position=new BABYLON.Vector3(0,5,20);
     boom.rotation.z=-Math.PI/2;
+    boomdx=boomdz=0;
 
     camera =new BABYLON.FreeCamera("mCam", new BABYLON.Vector3(0,6,-50), scene);
     camera.attachControl(canvas);
@@ -48,6 +49,8 @@ function gameloop()
     mons.position.z+=Math.sin(monsang)*monsspd;
     mons.rotation.y=-monsang;
 
+    boom.position.x+=boomdx;
+    boom.position.z+=boomdz;
     scene.render();
 }
 function herocontrol(event)
@@ -79,6 +82,15 @@ function herocontrol(event)
             camera.position.y=200;
             camera.position.x=camera.position.z=0;
             camera.rotation.x=Math.PI/2;
+        break;
+        case 'Enter':
+            boom.position.x=hero.position.x;
+            boom.position.z=hero.position.z;
+            boom.rotation.y=hero.rotation.y;
+            boomang=-boom.rotation.y;
+            boomspd=1;
+            boomdx=Math.cos(boomang)*boomspd;
+            boomdz=Math.sin(boomang)*boomspd;
         break;
     }
 }


### PR DESCRIPTION
**Explanation**. Spacebar fires the missile. In a more realistic game, the player would have to move over the missile to pick it up. We can do that later as a mod. For now, pressing the Enter key moves the missile over the player, and shoots the missile in the direction the player is facing.

The math, once again, is the same trigonometry used to move the player: determine a dx and dz based on the angle, and move the missile by adding dx and dz to the player’s position. Boomspd controls how fast the missile travels.

The setting up of dx and dz happens in the keyboard event handler, but since the missile moves automatically, the actual movement code is in the game loop.  Note that the game loop tries to move the missile immediately so we have to stop the missile by initializing dx and dz to zero in init().